### PR TITLE
changed display for right sidebar for smaller devices - slide out

### DIFF
--- a/wizer/static/css/style.css
+++ b/wizer/static/css/style.css
@@ -50,7 +50,6 @@ body {
     max-width: 100%;
 }
 
-
 .sidebar_right {
     width: 300px;
     float: right;
@@ -63,6 +62,7 @@ body {
     background-color: whitesmoke;
     padding-top: 75px;
     height: 100%;
+    transition: right 0.5s ease-out;
 }
 
 .sidebar_left .closebtn {
@@ -92,4 +92,41 @@ body {
     padding: 30px;
     margin-left: 40px;
     margin-top: 45px
+}
+
+#open-sidebar {
+    position: absolute;
+    top: 0;
+    right: -32px;
+    display: none;
+}
+
+.container-fluid > div{
+    position: relative;
+}
+
+@media only screen and (max-width: 992px) {
+    .content_left {
+        max-width: none;
+        flex: none;
+    }
+
+    .sidebar_right {
+        max-width: none;
+        position: fixed;
+        width: 300px;
+        top: 0;
+        /*left: 100%;*/
+        right: -300px;
+        overflow-x: hidden;
+    }
+
+    .sidebar_opened {
+        /*left: auto;*/
+        right: 0;
+    }
+
+    #open-sidebar {
+        display: block;
+    }
 }

--- a/wizer/static/js/script.js
+++ b/wizer/static/js/script.js
@@ -15,4 +15,29 @@ var redIcon = new L.Icon({
 
 $(document).ready(function () {
     $('[data-toggle="tooltip"]').tooltip();
+
+    // close right sidebar if clicked anywhere
+    $(window).click(closeSidebar);
+    // stop propagation if this element is clicked so close sidebar is not triggered
+    $('#sidebar').click(function (event) {
+        event.stopPropagation();
+    });
+    $('#open-sidebar').click(openSidebar);
 });
+
+function openSidebar(event) {
+    $("#sidebar").addClass('sidebar_opened');
+    $('#open-sidebar').hide();
+    // stop propagating so closeSidebar is not triggered right away
+    event.stopPropagation();
+}
+
+function closeSidebar() {
+    $("#sidebar").removeClass('sidebar_opened');
+    // we show the open button after the sidebar is not visible (css transition time is 0.5s)
+    if (window.innerWidth <= 992) {
+        setTimeout(function () {
+            $('#open-sidebar').show();
+        }, 500);
+    }
+}

--- a/wizer/templates/dashboard.html
+++ b/wizer/templates/dashboard.html
@@ -4,15 +4,18 @@
 {% block body %}
     <div class="container-fluid" style="margin-left: -20px">
         <div class="row">
-            <div class="col-sm-9">
+            <div class="col-sm-9 content_left">
                 {% include "lib/messages.html" %}
                 {% include 'plotting/plot_history.html' %}
                 {% include 'lib/table.html' %}
             </div>
-            <div class="col-sm-3 sidebar_right">
+            <div id="sidebar" class="col-sm-3 sidebar_right">
                 {% include 'plotting/plot_pie_chart.html' %}
                 {% include 'lib/sidenav/summary_facts.html' %}
                 {% include 'plotting/plot_trend.html' %}
+            </div>
+            <div id="open-sidebar">
+                <i class="fas fa-chart-pie fa-2x"></i>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Hi, I finished work on issue #5 
I changed it so the sidebar is hidden on smaller devices, but I also added a button on the top  right which displays the right sidebar.

Button to open right sidebar on small devices:
![image](https://user-images.githubusercontent.com/29523337/96864137-41eae700-1468-11eb-9117-e00c37b5dff8.png)

After clicking the pichart icon, the sidebar slides out (0.5s transition):
![image](https://user-images.githubusercontent.com/29523337/96864229-62b33c80-1468-11eb-9b93-42d6e159399f.png)

The sidebar can be closed (slides out) by clicking anywhere on the screen except the sidebar.

Let me know if you like this change or you were imagining it in a different way.