### PR TITLE
[CI] Added pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: check-ast
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: end-of-file-fixer
+        types: [python]
+      - id: flake8
+        additional_dependencies:
+          - flake8-string-format
+          - flake8-comprehensions
+          - flake8-builtins
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+        types: [python]
+
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black

--- a/setup/requirements/dev-requirements.in
+++ b/setup/requirements/dev-requirements.in
@@ -7,3 +7,4 @@ pip-tools
 pytest
 pytest-django
 selenium
+pre-commit


### PR DESCRIPTION
Added pre-commit hooks for black and flake8 as requested in #20 

Fixes #20 

Taken the liberty to add a few standard hooks like [check-ast](https://github.com/pre-commit/pre-commit-hooks#check-ast) , [check-yaml](https://github.com/pre-commit/pre-commit-hooks#check-yaml), [check-merge-conflict](https://github.com/pre-commit/pre-commit-hooks#check-merge-conflict), [end-of-file-fixer](https://github.com/pre-commit/pre-commit-hooks#check-merge-conflict)