### PR TITLE
ENH: Listen on all IP addresses in development environment, Add port …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Port-forwarding added when using the `run_docker.sh` script
 ### Changed
 * Made the extension of fit files to be imported case insensetive
 ### Fixed

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -4,6 +4,7 @@ docker build . -t wkz
 docker run \
   --name workoutizer \
   --rm \
+  -p 8000:8000 \
   -it \
   -v $(pwd):/wkz \
   wkz \

--- a/workoutizer/cli.py
+++ b/workoutizer/cli.py
@@ -52,7 +52,7 @@ def _is_main_run():
 def run(url):
     if not url:
         if os.getenv("WKZ_ENV") == "devel":
-            url = "127.0.0.1:8000"
+            url = "0.0.0.0:8000"
         else:
             url = f"{get_local_ip_address()}:8000"
     if _is_main_run():


### PR DESCRIPTION
As mentioned in #157 these changes enable port forwarding when using the `run_docker.sh` script

- [ ] tests added / passed
- [x] Ensure pre-commit formatting checks are passing
- [x] changelog entry
