### PR TITLE
ENH: Apply initial check to file importer to avoid spinning up a cluster all the time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 .git/
 venv/
+spike/
+selenium_ide/
+static/
+dask-worker-space/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-* Port-forwarding added when using the `run_docker.sh` script
+* Port-forwarding added when using the `run_docker.sh` script.
 ### Changed
-* Made the extension of fit files to be imported case insensetive
+* Made the extension of fit files to be imported case insensitive.
 ### Fixed
-* Ensure to close dask cluster after its usage to avoid running multiples, which
-  caused a memory leak.
+* Applied initial check to file importing process, which skips running a dask cluster
+  in case all existing files are preset in the db already. TODO
 
 ## [0.19.0](https://github.com/fgebhart/workoutizer/releases/tag/0.19.0) - 2021-06-13
 Note, when upgrading to this version you need to run `wkz reimport` in order to parse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 * Made the extension of fit files to be imported case insensitive.
 ### Fixed
-* Applied initial check to file importing process, which skips running a dask cluster
-  in case all existing files are preset in the db already. TODO
+* Apply initial check to file importing process, which skips running a dask cluster
+  in case all existing files are preset in the db already. This should fix a memory
+  leak.
+* Set `processes=False` for dask client to fix worker timeout when running
+  `wkz init --demo` ([#160](https://github.com/fgebhart/workoutizer/issues/160)).
 
 ## [0.19.0](https://github.com/fgebhart/workoutizer/releases/tag/0.19.0) - 2021-06-13
 Note, when upgrading to this version you need to run `wkz reimport` in order to parse

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN /bin/bash -c 'source /tmp/venv/bin/activate && pip install -r /workspaces/wo
 ENV SHELL /bin/zsh
 ENV WKZ_ENV='devel'
 ENV WKZ_LOG_LEVEL='DEBUG'
+ENV PYTHONBREAKPOINT=ipdb.set_trace
 
 EXPOSE 8000
 
@@ -37,6 +38,6 @@ COPY . /workspaces/workoutizer
 WORKDIR /workspaces/workoutizer
 
 # set convenience alias
-RUN echo 'alias run_all_tests="pytest tests -v -n4 --html=pytest-report.html"' >> ~/.zshrc
+RUN echo 'alias run_all_tests="pytest tests -v -n auto --html=pytest-report.html"' >> ~/.zshrc
 
 RUN /bin/bash -c 'source /tmp/venv/bin/activate && pip install -e . --no-deps --disable-pip-version-check'

--- a/setup/requirements/dev-requirements.in
+++ b/setup/requirements/dev-requirements.in
@@ -1,6 +1,7 @@
 black
 flake8
 isort
+ipdb
 IPython
 lxml>=4.6.3
 pip-tools

--- a/setup/requirements/dev-requirements.txt
+++ b/setup/requirements/dev-requirements.txt
@@ -23,7 +23,9 @@ click==8.0.1
 coverage==5.5
     # via pytest-cov
 decorator==5.0.9
-    # via ipython
+    # via
+    #   ipdb
+    #   ipython
 distlib==0.3.2
     # via virtualenv
 execnet==1.9.0
@@ -36,10 +38,14 @@ identify==2.2.10
     # via pre-commit
 iniconfig==1.1.1
     # via pytest
+ipdb==0.13.9
+    # via -r dev-requirements.in
 ipython-genutils==0.2.0
     # via traitlets
 ipython==7.24.1
-    # via -r dev-requirements.in
+    # via
+    #   -r dev-requirements.in
+    #   ipdb
 isort==5.8.0
     # via -r dev-requirements.in
 jedi==0.18.0
@@ -122,6 +128,7 @@ six==1.16.0
 toml==0.10.2
     # via
     #   black
+    #   ipdb
     #   pep517
     #   pre-commit
     #   pytest

--- a/tests/db_tests/browser_tests/test_dashboard_page.py
+++ b/tests/db_tests/browser_tests/test_dashboard_page.py
@@ -214,7 +214,7 @@ def test_trophy_icon_for_awarded_activities_in_table_are_displayed_correctly(db,
     webdriver.get(live_server.url + reverse("home"))
     # ... and verify that 2 trophies are present
     assert len(webdriver.find_elements_by_class_name("fa-trophy")) == 2
-    assert get_flat_list_of_pks_of_activities_in_top_awards() == [activity_1.pk, activity_2.pk]
+    assert set(get_flat_list_of_pks_of_activities_in_top_awards()) == {activity_1.pk, activity_2.pk}
 
     # also add total ascent value to activity 3...
     trace = models.Traces.objects.create(

--- a/tests/unit_tests/test_file_importer.py
+++ b/tests/unit_tests/test_file_importer.py
@@ -1,9 +1,12 @@
 import datetime
 from pathlib import Path
 
+import pytest
+
 from wkz.file_helper.parser import Parser
 from wkz.file_importer import (
     _all_files_in_db_already,
+    _check_and_parse_file,
     _convert_list_attributes_to_json,
     _get_all_files,
     _map_sport_name,
@@ -72,3 +75,23 @@ def test__all_files_in_db_already(demo_data_dir):
     # remove one file (thus db all md5sums of existing files plus one) and verify result is True
     fewer_files = all_files[:-1]
     assert _all_files_in_db_already(fewer_files, md5sums_from_db) is True
+
+
+@pytest.mark.parametrize("reimporting", (False, True))
+def test__check_and_parse_file(demo_data_dir, reimporting):
+    trace = Path(demo_data_dir) / "2019-09-18-16-02-35.fit"
+
+    # file md5sum is not in db
+    md5sums_from_db = []
+    md5sum, path_to_file, parsed_file = _check_and_parse_file(trace, demo_data_dir, md5sums_from_db, reimporting)
+    assert isinstance(md5sum, str)
+    assert isinstance(path_to_file, Path)
+    assert isinstance(parsed_file, Parser)
+
+    if not reimporting:
+        # file md5sum is in db
+        md5sums_from_db = [calc_md5(trace)]
+        md5sum, path_to_file, parsed_file = _check_and_parse_file(trace, demo_data_dir, md5sums_from_db, reimporting)
+        assert isinstance(md5sum, str)
+        assert isinstance(path_to_file, Path)
+        assert parsed_file is None

--- a/wkz/file_importer.py
+++ b/wkz/file_importer.py
@@ -358,15 +358,16 @@ def run_importer__dask(models: ModuleType, importing_demo_data: bool = False, re
     trace_files = _get_all_files(path_to_traces)
     _send_initial_info(len(trace_files), path_to_traces)
     md5sums_from_db = _get_md5sums_from_model(models.Traces)
+    num = 0
 
     # check whether all files are in db already or if a single new file was added
     if _all_files_in_db_already(trace_files, md5sums_from_db) and not reimporting:
+        _send_result_info(num)
         return
 
-    num = 0
     seen_md5sums = {}
     if trace_files:
-        with Client(processes=False) as client:
+        with Client(processes=False, threads_per_worker=1, n_workers=2) as client:
             distributed_results = client.map(
                 _check_and_parse_file,
                 trace_files,


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure pre-commit formatting checks are passing
- [x] changelog entry

This PR:
* adds `ipdb` debugger to the requirements: using `breakpoint()` brings up ipdb
* adds an initial check to file importer to check if all files are in db already and avoids spinning up a dask cluster all the time
* sets `processes=False` for the dask client to avoid the threading timeout issue seen in #160 