### PR TITLE
#Add support for chrome

### DIFF
--- a/.github/workflows/matrix_test.yml
+++ b/.github/workflows/matrix_test.yml
@@ -52,11 +52,16 @@ jobs:
         pip install -r setup/requirements/dev-requirements.txt
         pip install -e .
 
-    - name: Run Tests
+    - name: Run Tests with FireFox
       if: always()
       run: |
         pytest tests/ -vv -n2
 
+    - name: Run Browser Tests With Chrome
+      continue-on-error: True
+      run: |
+        pytest tests/db_tests/browser_tests -vv -n2 --browser=Chrome
+        
     - name: Init
       if: always()
       env:

--- a/.github/workflows/matrix_test.yml
+++ b/.github/workflows/matrix_test.yml
@@ -52,7 +52,7 @@ jobs:
         pip install -r setup/requirements/dev-requirements.txt
         pip install -e .
 
-    - name: Run Tests with FireFox
+    - name: Run Tests
       if: always()
       run: |
         pytest tests/ -vv -n2

--- a/.github/workflows/single_test.yml
+++ b/.github/workflows/single_test.yml
@@ -43,6 +43,11 @@ jobs:
         pip install -r setup/requirements/dev-requirements.txt
         pip install -e .
 
-    - name: Run Tests
+    - name: Run Tests With FireFox
       run: |
         pytest tests/ -vv -n2
+
+    - name: Run Browser Tests With Chrome
+      continue-on-error: True
+      run: |
+        pytest tests/db_tests/browser_tests -vv -n2 --browser=Chrome

--- a/.github/workflows/single_test.yml
+++ b/.github/workflows/single_test.yml
@@ -43,7 +43,7 @@ jobs:
         pip install -r setup/requirements/dev-requirements.txt
         pip install -e .
 
-    - name: Run Tests With FireFox
+    - name: Run Tests
       run: |
         pytest tests/ -vv -n2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-Placeholder section for unreleased changes.
+### Added
+* Added tests for Google Chrome browser
 
 ## [0.21.0](https://github.com/fgebhart/workoutizer/releases/tag/v0.21.0) - 2021-07-06
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:latest
 ENV DEBIAN_FRONTEND='noninteractive'
 # install sqlite3 package for the use of djangos db shell
 RUN apt-get update && \
-    apt-get install -y sqlite3 virtualenv vim git zsh wget htop curl firefox
+    apt-get install -y sqlite3 virtualenv vim git zsh wget htop curl firefox unzip
 
 # install oh-my-zsh
 RUN wget https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true
@@ -18,6 +18,16 @@ RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.28.0/geckod
 RUN sh -c 'tar -x geckodriver -zf geckodriver-v0.28.0-linux64.tar.gz -O > /usr/bin/geckodriver'
 RUN chmod +x /usr/bin/geckodriver
 RUN rm geckodriver-v0.28.0-linux64.tar.gz
+
+# Install chrome driver, use link for static version of chrome version
+# You can also use: https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+# But this can result in a new version breaking the setup
+RUN wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_91.0.4472.114-1_amd64.deb
+RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get install -fy
+RUN wget https://chromedriver.storage.googleapis.com/91.0.4472.101/chromedriver_linux64.zip
+RUN unzip -p chromedriver_linux64.zip > /usr/bin/chromedriver
+RUN chmod +x /usr/bin/chromedriver
+RUN rm google-chrome-stable_91.0.4472.114-1_amd64.deb chromedriver_linux64.zip
 
 # first copy only requirements files to only invalidate the next setps in case of changed requirements
 COPY ./setup/requirements/ /workspaces/workoutizer/setup/requirements/

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN rm geckodriver-v0.28.0-linux64.tar.gz
 # You can also use: https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 # But this can result in a new version breaking the setup
 RUN wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_91.0.4472.114-1_amd64.deb
-RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get install -fy
+RUN dpkg -i google-chrome-stable_91.0.4472.114-1_amd64.deb; apt-get install -fy
 RUN wget https://chromedriver.storage.googleapis.com/91.0.4472.101/chromedriver_linux64.zip
 RUN unzip -p chromedriver_linux64.zip > /usr/bin/chromedriver
 RUN chmod +x /usr/bin/chromedriver

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,23 @@ import pytest
 from workoutizer import settings as django_settings
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "-B",
+        "--browser",
+        dest="browser",
+        action="store",
+        default="firefox",
+        help="Add Browsers used for the test, Firefox is enabled by default, Chrome can be added",
+    )
+
+
+@pytest.fixture
+def browser(request):
+    "pytest fixture for browser"
+    return request.config.getoption("-B")
+
+
 @pytest.fixture
 def test_data_dir():
     return os.path.join(os.path.dirname(__file__), "data")

--- a/tests/db_tests/browser_tests/conftest.py
+++ b/tests/db_tests/browser_tests/conftest.py
@@ -2,17 +2,23 @@ import datetime
 from pathlib import Path
 
 import pytest
-from selenium.webdriver import Firefox
-from selenium.webdriver.firefox.options import Options
+from selenium.webdriver import Chrome, ChromeOptions, Firefox, FirefoxOptions
 
 from workoutizer import settings as django_settings
 
 
+# https://qxf2.com/blog/selenium-cross-browser-cross-platform-pytest/
 @pytest.fixture
-def webdriver():
-    options = Options()
-    options.headless = True
-    driver = Firefox(options=options)
+def webdriver(browser):
+    if browser.lower() == "firefox":
+        options = FirefoxOptions()
+        options.headless = True
+        driver = Firefox(options=options)
+    if browser.lower() == "chrome":
+        options = ChromeOptions()
+        options.add_argument("--no-sandbox")  # This can probally be removed when #30 is fixed
+        options.headless = True
+        driver = Chrome(options=options)
     driver.set_window_size(1280, 1024)
     yield driver
     driver.quit()


### PR DESCRIPTION
I tried my hand at adding the needed infrastructure for #85. I only made sure the tests are running correctly, the results of the tests where ignored during the process. The Chrome tests are for now also ignored if they fail, this way it does not prevent further releases etc.

When the tests with Chrome are successful we could parameterize the tests with both browsers, but for know this seemed the better solution.

- [X] tests added / passed
- [X] Ensure pre-commit formatting checks are passing
- [X] changelog entry
