### PR TITLE
TST: Fix chrome browser tests and run them together with firefox via parametrization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+ /CHANGELOG.md merge=union
+ 

--- a/.github/workflows/matrix_test.yml
+++ b/.github/workflows/matrix_test.yml
@@ -1,5 +1,5 @@
 
-name: Test
+name: Matrix Test
 
 on:
   pull_request:
@@ -57,11 +57,6 @@ jobs:
       run: |
         pytest tests/ -vv -n2
 
-    - name: Run Browser Tests With Chrome
-      continue-on-error: True
-      run: |
-        pytest tests/db_tests/browser_tests -vv -n2 --browser=Chrome
-        
     - name: Init
       if: always()
       env:

--- a/.github/workflows/single_test.yml
+++ b/.github/workflows/single_test.yml
@@ -1,5 +1,5 @@
 
-name: Push Test
+name: Single Test
 
 on: [push]
 
@@ -46,8 +46,3 @@ jobs:
     - name: Run Tests
       run: |
         pytest tests/ -vv -n2
-
-    - name: Run Browser Tests With Chrome
-      continue-on-error: True
-      run: |
-        pytest tests/db_tests/browser_tests -vv -n2 --browser=Chrome

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-* Added tests for Google Chrome browser
+* Run browser tests not only for firefox but also for chrome, thus workoutizer now
+  officially supports chrome.
 ### Fixed
-* Fix not mounting block devices due to flawed logic
+* Fix not mounting block devices due to flawed logic.
 
 ## [0.21.0](https://github.com/fgebhart/workoutizer/releases/tag/v0.21.0) - 2021-07-06
 ### Added

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,23 +5,6 @@ import pytest
 from workoutizer import settings as django_settings
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "-B",
-        "--browser",
-        dest="browser",
-        action="store",
-        default="firefox",
-        help="Add Browsers used for the test, Firefox is enabled by default, Chrome can be added",
-    )
-
-
-@pytest.fixture
-def browser(request):
-    "pytest fixture for browser"
-    return request.config.getoption("-B")
-
-
 @pytest.fixture
 def test_data_dir():
     return os.path.join(os.path.dirname(__file__), "data")

--- a/tests/db_tests/browser_tests/conftest.py
+++ b/tests/db_tests/browser_tests/conftest.py
@@ -7,16 +7,16 @@ from selenium.webdriver import Chrome, ChromeOptions, Firefox, FirefoxOptions
 from workoutizer import settings as django_settings
 
 
-# https://qxf2.com/blog/selenium-cross-browser-cross-platform-pytest/
-@pytest.fixture
-def webdriver(browser):
-    if browser.lower() == "firefox":
+@pytest.fixture(params=["chrome", "firefox"])
+def webdriver(request):
+    if request.param == "firefox":
         options = FirefoxOptions()
         options.headless = True
         driver = Firefox(options=options)
-    if browser.lower() == "chrome":
+    if request.param == "chrome":
         options = ChromeOptions()
         options.add_argument("--no-sandbox")  # This can probally be removed when #30 is fixed
+        options.add_argument("--disable-dev-shm-usage")  # https://stackoverflow.com/a/53970825
         options.headless = True
         driver = Chrome(options=options)
     driver.set_window_size(1280, 1024)

--- a/tests/db_tests/browser_tests/test_activity_page.py
+++ b/tests/db_tests/browser_tests/test_activity_page.py
@@ -328,6 +328,7 @@ def test_add_activity_page(insert_sport, webdriver, live_server):
     assert webdriver.current_url == live_server.url + reverse("add-activity")
 
     # set name
+    WebDriverWait(webdriver, 3).until(EC.element_to_be_clickable((By.ID, "id_name")))
     webdriver.find_element(By.ID, "id_name").click()
     webdriver.find_element(By.ID, "id_name").clear()
     webdriver.find_element(By.ID, "id_name").send_keys("Dummy Activity")

--- a/tests/db_tests/browser_tests/test_activity_page.py
+++ b/tests/db_tests/browser_tests/test_activity_page.py
@@ -228,26 +228,20 @@ def test_edit_activity_page(import_one_activity, live_server, webdriver, insert_
 
     assert webdriver.find_element_by_class_name("navbar-brand").text == "Edit Activity: Noon Cycling In Bad Schandau"
     assert webdriver.find_element_by_id("submit-button").text == "  SAVE"
-    assert (
-        webdriver.find_element_by_tag_name("form").text
-        == """Activity Name
-Sport
----------
-Cycling
-MTB
-Date
-Duration [HH:MM:SS]
-Distance [in km]
-Description
-Consider Activity for Awards
-
-Lap Data
-
-
-  SAVE
-CANCEL
-  DELETE"""
-    )
+    form_text = webdriver.find_element_by_tag_name("form").text
+    assert "Activity Name" in form_text
+    assert "Sport" in form_text
+    assert "Cycling" in form_text
+    assert "MTB" in form_text
+    assert "Date" in form_text
+    assert "Duration [HH:MM:SS]" in form_text
+    assert "Distance [in km]" in form_text
+    assert "Description" in form_text
+    assert "Consider Activity for Awards" in form_text
+    assert "Lap Data" in form_text
+    assert "SAVE" in form_text
+    assert "CANCEL" in form_text
+    assert "DELETE" in form_text
 
     links = [link.text for link in webdriver.find_elements_by_tag_name("a")]
     assert "DASHBOARD" in links
@@ -283,11 +277,13 @@ CANCEL
     webdriver.find_element(By.CSS_SELECTOR, "tr:nth-child(4) > .day:nth-child(5)").click()
     webdriver.find_element(By.CSS_SELECTOR, "tr:nth-child(3) > .day:nth-child(3)").click()
     webdriver.find_element(By.CSS_SELECTOR, ".fa-clock-o").click()
+    WebDriverWait(webdriver, 3).until(EC.element_to_be_clickable((By.CSS_SELECTOR, "td:nth-child(3) .fa-chevron-down")))
     webdriver.find_element(By.CSS_SELECTOR, "td:nth-child(3) .fa-chevron-down").click()
 
     # also edit lap data
     webdriver.find_element(By.ID, "edit-lap-data").click()
     lap_input_0 = webdriver.find_element(By.ID, "id_form-0-label")
+    WebDriverWait(webdriver, 3).until(EC.element_to_be_clickable((By.ID, "id_form-0-label")))
     lap_input_0.clear()
     lap_input_0.send_keys("lap label 0")
 
@@ -343,6 +339,7 @@ def test_add_activity_page(insert_sport, webdriver, live_server):
     webdriver.find_element(By.ID, "id_date").click()
     webdriver.find_element(By.CSS_SELECTOR, ".fa-clock-o").click()
     # change hours
+    WebDriverWait(webdriver, 3).until(EC.element_to_be_clickable((By.CSS_SELECTOR, "td:nth-child(1) .fa-chevron-up")))
     webdriver.find_element(By.CSS_SELECTOR, "td:nth-child(1) .fa-chevron-up").click()
     # change minutes
     webdriver.find_element(By.CSS_SELECTOR, "td:nth-child(3) .fa-chevron-down").click()
@@ -530,8 +527,9 @@ def test_trophy_icon_for_awarded_activity_is_displayed_correctly(db, live_server
     assert len(webdriver.find_elements_by_class_name("fa-trophy")) == 1
 
     trophy = webdriver.find_element_by_class_name("fa-trophy")
-    gold = "rgb(255, 215, 0)"
-    assert trophy.value_of_css_property("color") == gold
+    color = trophy.value_of_css_property("color")
+    assert "255, 215, 0" in color
+    assert "rgb" in color
 
     # add best sections
     models.BestSection.objects.create(

--- a/tests/db_tests/browser_tests/test_dashboard_page.py
+++ b/tests/db_tests/browser_tests/test_dashboard_page.py
@@ -53,6 +53,7 @@ def test_dashboard_page__complete(import_demo_data, live_server, webdriver):
     assert webdriver.find_element_by_class_name("navbar-brand").text == "Dashboard"
 
     # check that all activity names are in the table
+    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.TAG_NAME, "td")))
     table_data = [cell.text for cell in webdriver.find_elements_by_tag_name("td")]
     assert "Noon Jogging in Heidelberg" in table_data
     assert "Swimming" in table_data
@@ -136,6 +137,7 @@ def test_dashboard__infinite_scroll(tracks_in_tmpdir, live_server, webdriver, in
     webdriver.get(live_server.url + reverse("home"))
 
     # number of rows equals the number of rows per page, since only one page is loaded
+    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.ID, "activities-table-row")))
     table_rows = [cell.text for cell in webdriver.find_elements_by_id("activities-table-row")]
     assert len(table_rows) + 1 == rows_per_page
 
@@ -146,6 +148,7 @@ def test_dashboard__infinite_scroll(tracks_in_tmpdir, live_server, webdriver, in
     WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.ID, "end-of-activities")))
 
     # again check number of table rows
+    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.ID, "activities-table-row")))
     table_rows = [cell.text for cell in webdriver.find_elements_by_id("activities-table-row")]
     assert len(table_rows) + 1 == nr_of_inserted_activities
 
@@ -199,6 +202,7 @@ def test_trophy_icon_for_awarded_activities_in_table_are_displayed_correctly(db,
     )
     webdriver.get(live_server.url + reverse("home"))
     # ... and verify that 1 trophy is present
+    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.CLASS_NAME, "fa-trophy")))
     assert len(webdriver.find_elements_by_class_name("fa-trophy")) == 1
     assert get_flat_list_of_pks_of_activities_in_top_awards() == [activity_1.pk]
 
@@ -213,6 +217,7 @@ def test_trophy_icon_for_awarded_activities_in_table_are_displayed_correctly(db,
     )
     webdriver.get(live_server.url + reverse("home"))
     # ... and verify that 2 trophies are present
+    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.CLASS_NAME, "fa-trophy")))
     assert len(webdriver.find_elements_by_class_name("fa-trophy")) == 2
     assert set(get_flat_list_of_pks_of_activities_in_top_awards()) == {activity_1.pk, activity_2.pk}
 
@@ -228,5 +233,6 @@ def test_trophy_icon_for_awarded_activities_in_table_are_displayed_correctly(db,
     activity_3.save()
     webdriver.get(live_server.url + reverse("home"))
     # ... and verify that 3 trophies are present
+    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.CLASS_NAME, "fa-trophy")))
     assert len(webdriver.find_elements_by_class_name("fa-trophy")) == 3
-    assert get_flat_list_of_pks_of_activities_in_top_awards() == [activity_1.pk, activity_2.pk, activity_3.pk]
+    assert set(get_flat_list_of_pks_of_activities_in_top_awards()) == set([activity_1.pk, activity_2.pk, activity_3.pk])

--- a/tests/db_tests/browser_tests/test_generic.py
+++ b/tests/db_tests/browser_tests/test_generic.py
@@ -67,7 +67,7 @@ def test_sidebar(live_server, webdriver):
     # again minimize sidebar
     webdriver.find_element(By.CSS_SELECTOR, ".fa-chevron-left").click()
     # maximize
-    WebDriverWait(webdriver, 3).until(EC.element_to_be_clickable((By.CSS_SELECTOR, ".fa-chevron-right")))
+    WebDriverWait(webdriver, 3).until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".fa-chevron-right")))
     webdriver.find_element(By.CSS_SELECTOR, ".fa-chevron-right").click()
     assert webdriver.current_url == live_server.url + reverse("home")
 

--- a/tests/db_tests/browser_tests/test_generic.py
+++ b/tests/db_tests/browser_tests/test_generic.py
@@ -267,7 +267,8 @@ def test_keyboard_shortcuts__activity_and_sport(flush_db, live_server, webdriver
     ac.key_up("e")
     _try_to_perform_chain(ac)
 
-    assert webdriver.current_url == live_server.url + "/activity/1/edit/"
+    # assert webdriver.current_url == live_server.url + "/activity/1/edit/"
+    delayed_assertion(lambda: webdriver.current_url, operator.eq, live_server.url + "/activity/1/edit/")
 
     webdriver.get(live_server.url + "/sport/bowling")
     assert webdriver.current_url == live_server.url + "/sport/bowling"

--- a/tests/db_tests/browser_tests/test_generic.py
+++ b/tests/db_tests/browser_tests/test_generic.py
@@ -1,4 +1,5 @@
 import operator
+import time
 
 import pytest
 from django.urls import reverse
@@ -20,10 +21,13 @@ def test_sidebar(live_server, webdriver):
     def _assert_only_selected_link_is_highlighted(red_link_text: str):
         all_links = webdriver.find_elements(By.TAG_NAME, "a")
         for link in all_links:
+            color = link.value_of_css_property("color")
             if link.text == red_link_text:
-                assert link.value_of_css_property("color") == "rgb(239, 129, 87)"
+                assert "rgb" in color
+                assert "239, 129, 87" in color
             else:
-                assert link.value_of_css_property("color") != "rgb(239, 129, 87)"
+                assert "rgb" in color
+                assert "239, 129, 87" not in color
 
     webdriver.get(live_server.url + reverse("home"))
     assert webdriver.find_element_by_class_name("navbar-brand").text == "Dashboard"
@@ -63,11 +67,12 @@ def test_sidebar(live_server, webdriver):
     # again minimize sidebar
     webdriver.find_element(By.CSS_SELECTOR, ".fa-chevron-left").click()
     # maximize
+    WebDriverWait(webdriver, 3).until(EC.element_to_be_clickable((By.CSS_SELECTOR, ".fa-chevron-right")))
     webdriver.find_element(By.CSS_SELECTOR, ".fa-chevron-right").click()
     assert webdriver.current_url == live_server.url + reverse("home")
 
 
-def test_responsiveness(live_server, webdriver):
+def test_responsiveness(live_server, webdriver, take_screenshot):
     # first go to dashboard page
     webdriver.get(live_server.url + reverse("home"))
     assert webdriver.find_element_by_class_name("navbar-brand").text == "Dashboard"
@@ -106,6 +111,7 @@ def test_responsiveness(live_server, webdriver):
 
     # now toggle the sidebar to expand again
     webdriver.find_element(By.CLASS_NAME, "navbar-toggler").click()
+    time.sleep(1)  # wait a moment until sidebar reveals, in order to make chrome tests pass
     # sidebar items should be present again
     webdriver.find_element(By.LINK_TEXT, "WORKOUTIZER")
     webdriver.find_element(By.LINK_TEXT, "SPORTS")
@@ -130,11 +136,19 @@ def test_responsiveness(live_server, webdriver):
     webdriver.find_element(By.CLASS_NAME, "navbar-kebab").click()
 
     # verify navbar items are visible and interactable again
+    WebDriverWait(webdriver, 3).until(EC.element_to_be_clickable((By.ID, "add-activity-button")))
     webdriver.find_element(By.ID, "add-activity-button").click()
+    assert webdriver.current_url == live_server.url + reverse("add-activity")
+
     webdriver.find_element(By.CLASS_NAME, "navbar-kebab").click()
+    WebDriverWait(webdriver, 3).until(EC.element_to_be_clickable((By.ID, "help-button")))
     webdriver.find_element(By.ID, "help-button").click()
+    assert webdriver.current_url == live_server.url + reverse("help")
+
     webdriver.find_element(By.CLASS_NAME, "navbar-kebab").click()
+    WebDriverWait(webdriver, 3).until(EC.element_to_be_clickable((By.ID, "settings-button")))
     webdriver.find_element(By.ID, "settings-button").click()
+    assert webdriver.current_url == live_server.url + reverse("settings")
 
 
 def test_custom_navbar_items(db, live_server, webdriver, import_one_activity):

--- a/tests/db_tests/browser_tests/test_generic.py
+++ b/tests/db_tests/browser_tests/test_generic.py
@@ -72,7 +72,7 @@ def test_sidebar(live_server, webdriver):
     assert webdriver.current_url == live_server.url + reverse("home")
 
 
-def test_responsiveness(live_server, webdriver, take_screenshot):
+def test_responsiveness(live_server, webdriver):
     # first go to dashboard page
     webdriver.get(live_server.url + reverse("home"))
     assert webdriver.find_element_by_class_name("navbar-brand").text == "Dashboard"

--- a/tests/db_tests/browser_tests/test_settings_page.py
+++ b/tests/db_tests/browser_tests/test_settings_page.py
@@ -113,6 +113,10 @@ def test_settings_page__edit_and_submit_form(live_server, webdriver):
     # basically clicking somewhere else to trigger submitting the change
     webdriver.find_element(By.ID, "navigation").click()
 
+    # wait until loading image shows up and disappears again
+    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.ID, "loading-bar")))
+    WebDriverWait(webdriver, 3).until(EC.invisibility_of_element_located((By.ID, "loading-bar")))
+
     delayed_assertion(lambda: models.get_settings().path_to_trace_dir, operator.eq, "some/dummy/path")
 
     WebDriverWait(webdriver, 3).until(EC.element_to_be_clickable((By.ID, "id_path_to_garmin_device")))

--- a/tests/db_tests/browser_tests/test_settings_page.py
+++ b/tests/db_tests/browser_tests/test_settings_page.py
@@ -84,8 +84,8 @@ def test_settings_page__demo_activity_present__delete_it(import_demo_data, live_
     webdriver.get(live_server.url + reverse("home"))
 
     # verify that all demo data got deleted
-    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.CLASS_NAME, "logo-normal")))
-    assert models.Activity.objects.filter(is_demo_activity=True).count() == 0
+    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.ID, "dropdown-btn")))
+    delayed_assertion(models.Activity.objects.filter(is_demo_activity=True).count, operator.eq, 0)
 
     # no delete demo data button present
     with pytest.raises(NoSuchElementException):

--- a/tests/db_tests/browser_tests/test_settings_page.py
+++ b/tests/db_tests/browser_tests/test_settings_page.py
@@ -81,8 +81,10 @@ def test_settings_page__demo_activity_present__delete_it(import_demo_data, live_
     second_delete_button = webdriver.find_element_by_class_name("btn-space")
     assert second_delete_button.text == "  DELETE"
     second_delete_button.click()
+    webdriver.get(live_server.url + reverse("home"))
 
     # verify that all demo data got deleted
+    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.CLASS_NAME, "logo-normal")))
     assert models.Activity.objects.filter(is_demo_activity=True).count() == 0
 
     # no delete demo data button present
@@ -118,7 +120,11 @@ def test_settings_page__edit_and_submit_form(live_server, webdriver):
     garmin_device_input_field = webdriver.find_element(By.ID, "id_path_to_garmin_device")
     garmin_device_input_field.clear()
     garmin_device_input_field.send_keys("garmin/dummy/path")
+    # click somewhere to trigger updating settings
     webdriver.find_element(By.ID, "navigation").click()
+    # wait until loading image shows up and disappears again
+    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.ID, "loading-bar")))
+    WebDriverWait(webdriver, 3).until(EC.invisibility_of_element_located((By.ID, "loading-bar")))
     delayed_assertion(lambda: models.get_settings().path_to_garmin_device, operator.eq, "garmin/dummy/path")
 
     # got removed, should not be accessible

--- a/tests/db_tests/browser_tests/test_settings_page.py
+++ b/tests/db_tests/browser_tests/test_settings_page.py
@@ -84,8 +84,7 @@ def test_settings_page__demo_activity_present__delete_it(import_demo_data, live_
     webdriver.get(live_server.url + reverse("home"))
 
     # verify that all demo data got deleted
-    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.ID, "dropdown-btn")))
-    delayed_assertion(models.Activity.objects.filter(is_demo_activity=True).count, operator.eq, 0)
+    assert models.Activity.objects.filter(is_demo_activity=True).count() == 0
 
     # no delete demo data button present
     with pytest.raises(NoSuchElementException):

--- a/tests/db_tests/browser_tests/test_settings_page.py
+++ b/tests/db_tests/browser_tests/test_settings_page.py
@@ -5,6 +5,8 @@ import pytest
 from django.urls import reverse
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
 
 from tests.utils import delayed_assertion
 from wkz import models
@@ -103,6 +105,7 @@ def test_settings_page__edit_and_submit_form(live_server, webdriver):
     # Note, that with using htmx to update the settings form, all fields are submitted once their values got changed
 
     # modify values by inserting into input fields
+    WebDriverWait(webdriver, 3).until(EC.element_to_be_clickable((By.ID, "id_path_to_trace_dir")))
     trace_dir_input_field = webdriver.find_element(By.ID, "id_path_to_trace_dir")
     trace_dir_input_field.clear()
     trace_dir_input_field.send_keys("some/dummy/path")
@@ -111,6 +114,7 @@ def test_settings_page__edit_and_submit_form(live_server, webdriver):
 
     delayed_assertion(lambda: models.get_settings().path_to_trace_dir, operator.eq, "some/dummy/path")
 
+    WebDriverWait(webdriver, 3).until(EC.element_to_be_clickable((By.ID, "id_path_to_garmin_device")))
     garmin_device_input_field = webdriver.find_element(By.ID, "id_path_to_garmin_device")
     garmin_device_input_field.clear()
     garmin_device_input_field.send_keys("garmin/dummy/path")

--- a/tests/db_tests/browser_tests/test_sport_page.py
+++ b/tests/db_tests/browser_tests/test_sport_page.py
@@ -143,6 +143,7 @@ def test_sport_page__infinite_scroll(live_server, webdriver, insert_activity, in
     webdriver.get(live_server.url + "/sport/skiing")
 
     # number of rows equals the number of rows per page, since only one page is loaded
+    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.ID, "activities-table-row")))
     table_rows = [cell.text for cell in webdriver.find_elements_by_id("activities-table-row")]
     assert len(table_rows) + 1 == rows_per_page
 

--- a/tests/db_tests/browser_tests/test_sport_page.py
+++ b/tests/db_tests/browser_tests/test_sport_page.py
@@ -168,6 +168,7 @@ def test_sport_page__no_activities_selected_for_plot(live_server, webdriver, ins
     webdriver.get(live_server.url + "/sport/bungee-jumping")
 
     # even though the activity data is far in the past, the rows will be shown in the table
+    WebDriverWait(webdriver, 3).until(EC.presence_of_element_located((By.ID, "activities-table-row")))
     table_rows = [cell.text for cell in webdriver.find_elements_by_id("activities-table-row")]
     assert len(table_rows) == 5
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,8 +6,8 @@ from tenacity import retry, stop_after_attempt, wait_exponential
     wait=wait_exponential(multiplier=3, min=1, max=5),
     stop=stop_after_attempt(3),
 )
-def delayed_assertion(func, operator, right):
+def delayed_assertion(func, operator, result):
     """
     Helper function to check if a function evaluates to given value with a fixed number of retries.
     """
-    assert operator(func(), right)
+    assert operator(func(), result)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,4 +10,4 @@ def delayed_assertion(func, operator, result):
     """
     Helper function to check if a function evaluates to given value with a fixed number of retries.
     """
-    assert operator(func(), result), f"function: {func} did not return a result which is {operator} {result}"
+    assert operator(func(), result), f"function {func} returned {func()}, which is not {operator} {result}"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,4 +10,4 @@ def delayed_assertion(func, operator, result):
     """
     Helper function to check if a function evaluates to given value with a fixed number of retries.
     """
-    assert operator(func(), result)
+    assert operator(func(), result), f"function: {func} did not return a result which is {operator} {result}"

--- a/wkz/activity_views.py
+++ b/wkz/activity_views.py
@@ -183,25 +183,26 @@ class ActivityDeleteView(DeleteView):
 
 class DemoActivityDeleteView(DeleteView):
     template_name = "activity/demo_activity_confirm_delete.html"
-    activities = Activity.objects.filter(is_demo_activity=True)
 
     def get(self, request, *args, **kwargs):
+        activities = Activity.objects.filter(is_demo_activity=True)
         sports = Sport.objects.all().order_by("name")
-        log.debug(f"activities to be deleted: {self.activities}")
+        log.debug(f"activities to be deleted: {activities}")
         return render(
             request,
             self.template_name,
             {
                 "sports": sports,
-                "activities": self.activities,
+                "activities": activities,
                 "form_field_ids": get_all_form_field_ids(),
                 "page_name": "Delete Demo Activities",
             },
         )
 
     def post(self, request, *args, **kwargs):
-        log.debug(f"deleting: {self.activities}")
-        for activity in self.activities:
+        activities = Activity.objects.filter(is_demo_activity=True)
+        log.debug(f"deleting: {activities}")
+        for activity in activities:
             activity.delete()
         log.info("deleted demo activities")
         return HttpResponseRedirect(reverse("home"))


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure pre-commit formatting checks are passing
- [x] changelog entry

What I did:
* fixed the chrome browser tests (added a bunch of waits basically)
* parametrized the `webdriver` fixture to run both Firefox and Chrome
* removed the additional chrome step from the ci workflow files

However, the following test seems to still keep failing:
```
FAILED tests/db_tests/browser_tests/test_settings_page.py::test_settings_page__demo_activity_present__delete_it[firefox]
```
Will have a look into this failing test whenever I find some time.