### PR TITLE
DOC: Define `WorkingDirectory` in systemd file

### DIFF
--- a/setup/Readme.md
+++ b/setup/Readme.md
@@ -97,6 +97,7 @@ After=syslog.target network.target
 
 [Service]
 User=pi
+WorkingDirectory=~
 ExecStart=/home/pi/venv/bin/wkz run
 Restart=on-abort
 


### PR DESCRIPTION
If not defined the `dask-worker-space` directory can not be created. This could also be a bug in the dask implementation, But defining the `WorkingDirectory` for the service seems to be good practice anyway
