### PR TITLE
FIX: Use the same settings for all maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Fixed
 * Correctly display activity duration as timedelta formatted as `HH:MM:SS` instead of
   raw seconds in time series plots on activity page.
+* Use the same layer type for all maps.
 ## Changed
 * #189: Upgrade `fitparse` to most recent version and use `enhanced_altitude` instead of
   `altitude` value when parsing fit files, since `enhanced_altitude` seems to contain

--- a/tests/db_tests/browser_tests/test_activity_page.py
+++ b/tests/db_tests/browser_tests/test_activity_page.py
@@ -116,6 +116,16 @@ def test_activity_page__complete__fit(import_one_activity, live_server, webdrive
     assert webdriver.find_element_by_class_name("bk-root").text == "Show Laps"
     assert len(webdriver.find_elements_by_class_name("bk-canvas")) == 3
 
+    # check that streets is the default map layer
+    default_layer = [
+        span.text
+        for span in webdriver.find_elements_by_css_selector(
+            ".leaflet-control-layers-inline .leaflet-control-layers-base input:checked+span"
+        )
+    ]
+    assert len(default_layer) == 1
+    assert "Streets" in default_layer
+
 
 def test_activity_page__complete__gpx(import_one_activity, live_server, webdriver):
     import_one_activity("cycling_walchensee.gpx")
@@ -185,6 +195,16 @@ def test_activity_page__complete__gpx(import_one_activity, live_server, webdrive
 
     # check that only one bokeh plot is available
     assert len(webdriver.find_elements_by_class_name("bk-canvas")) == 1
+
+    # check that streets is the default map layer
+    default_layer = [
+        span.text
+        for span in webdriver.find_elements_by_css_selector(
+            ".leaflet-control-layers-inline .leaflet-control-layers-base input:checked+span"
+        )
+    ]
+    assert len(default_layer) == 1
+    assert "Streets" in default_layer
 
 
 def test_edit_activity_page(import_one_activity, live_server, webdriver, insert_sport):

--- a/tests/db_tests/browser_tests/test_sport_page.py
+++ b/tests/db_tests/browser_tests/test_sport_page.py
@@ -129,6 +129,16 @@ def test_sport_page__complete(import_demo_data, live_server, webdriver):
     # check that it is possible to click on the fullscreen toggle using leaflet-ui
     webdriver.find_element_by_css_selector(".leaflet-control-zoom-fullscreen").click()
 
+    # check that streets is the default map layer
+    default_layer = [
+        span.text
+        for span in webdriver.find_elements_by_css_selector(
+            ".leaflet-control-layers-inline .leaflet-control-layers-base input:checked+span"
+        )
+    ]
+    assert len(default_layer) == 1
+    assert "Streets" in default_layer
+
 
 def test_sport_page__infinite_scroll(live_server, webdriver, insert_activity, insert_sport):
     rows_per_page = configuration.number_of_rows_per_page_in_table
@@ -194,3 +204,13 @@ def test_sport_page__no_activities_selected_for_plot(live_server, webdriver, ins
     assert "Topo" in spans
     assert "Terrain" in spans
     assert "Satellite" in spans
+
+    # check that streets is the default map layer
+    default_layer = [
+        span.text
+        for span in webdriver.find_elements_by_css_selector(
+            ".leaflet-control-layers-inline .leaflet-control-layers-base input:checked+span"
+        )
+    ]
+    assert len(default_layer) == 1
+    assert "Streets" in default_layer

--- a/wkz/templates/map/activity_map.html
+++ b/wkz/templates/map/activity_map.html
@@ -15,25 +15,7 @@
 </div>
 
 <script>
-    // config options of leaflet-ui plugin: https://github.com/Raruto/leaflet-ui
-    var map = L.map('leaflet_map', {
-        center: [41.4583, 12.7059],  // needs value to initialize
-        zoom: 5,                     // needs value to initialize
-        mapTypeId: 'streets',
-        mapTypeIds: ['streets', 'topo', 'osm', 'terrain', 'satellite'],
-        gestureHandling: false,     // zoom with Cmd + Scroll
-        zoomControl: true,          // plus minus buttons
-        pegmanControl: false,
-        locateControl: false,
-        fullscreenControl: true,
-        layersControl: true,
-        minimapControl: false,
-        editInOSMControl: false,
-        loadingControl: false,
-        searchControl: false,
-        disableDefaultUI: false,
-        printControl: false,
-    });
+    {% include "map/map_settings.html" %}
 
     {% for line, _ in traces %}
         coordinates = {{ line.coordinates }};

--- a/wkz/templates/map/map_settings.html
+++ b/wkz/templates/map/map_settings.html
@@ -1,0 +1,19 @@
+// config options of leaflet-ui plugin: https://github.com/Raruto/leaflet-ui
+var map = L.map('leaflet_map', {
+    center: [41.4583, 12.7059],  // needs value to initialize
+    zoom: 5,                     // needs value to initialize
+    mapTypeId: 'streets',
+    mapTypeIds: ['streets', 'topo', 'osm', 'terrain', 'satellite'],
+    gestureHandling: false,     // zoom with Cmd + Scroll
+    zoomControl: true,          // plus minus buttons
+    pegmanControl: false,
+    locateControl: false,
+    fullscreenControl: true,
+    layersControl: true,
+    minimapControl: false,
+    editInOSMControl: false,
+    loadingControl: false,
+    searchControl: false,
+    disableDefaultUI: false,
+    printControl: false,
+});

--- a/wkz/templates/map/sport_map.html
+++ b/wkz/templates/map/sport_map.html
@@ -14,25 +14,8 @@
 </div>
 
 <script>
-    // config options of leaflet-ui plugin: https://github.com/Raruto/leaflet-ui
-    var map = L.map('leaflet_map', {
-        center: [41.4583, 12.7059],  // needs value to initialize
-        zoom: 1,                     // needs value to initialize
-        mapTypeId: 'topo',
-        mapTypeIds: ['topo', 'streets', 'osm', 'terrain', 'satellite'],
-        gestureHandling: false,     // zoom with Cmd + Scroll
-        zoomControl: true,          // plus minus buttons
-        pegmanControl: false,
-        locateControl: false,
-        fullscreenControl: true,
-        layersControl: true,
-        minimapControl: false,
-        editInOSMControl: false,
-        loadingControl: false,
-        searchControl: false,
-        disableDefaultUI: false,
-        printControl: false,
-    });
+    {% include "map/map_settings.html" %}
+    
     map.once('idle', function () { /* Waiting for map init */
     });
 


### PR DESCRIPTION
On the sport overview the default chosen map was `Topo` on the activity view it was `Streets`. Made them consistent with each other.

- [x] tests added / passed
- [x] Ensure pre-commit formatting checks are passing
- [x] changelog entry
