### PR TITLE
FIX: adapt mount mechanism to gio not returning any output message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 * Fixed retrieving geo referenced location names by adding `county` as additional
   field. This will again provide a geo name for activities with particular coordinates.
+* Updated the mounting mechanism to account for new `gio` on Raspberry Pi OS bullseye
+  which does no longer return the path to a mounted device. The mount mechanism was
+  changed in a way that it simply checks whether a device is mounted a the expected
+  location. This should work with in all scenarios.
 ### Changed
 * moved `initial_trace_data` dir from `setup` to `wkz` because in some cases this led
   to a failure of missing dir when initializing workoutizer with the `--demo` flag.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,7 @@ MOCKED_RETRY = 3
 
 
 @pytest.fixture
-def mock_mount_waiting_time(monkeypatch):
+def mock_mount_waiting_time(monkeypatch) -> None:
     from wkz.device import mount
 
     # mock number of retries and waiting time to speed up test execution
@@ -103,3 +103,21 @@ def _mock_lsusb(monkeypatch) -> None:
         return monkeypatch.setattr(subprocess, "check_output", lsusb_output)
 
     return mock
+
+
+@pytest.fixture
+def mock_expected_device_paths(monkeypatch, tmp_path) -> None:
+    from wkz.device import mount
+
+    # mock expected device paths in order to test these to be real dirs
+    mtp_path = tmp_path / "mtp"
+    mtp_path.mkdir()
+    p = mtp_path / "some_mtp_file.fit"
+    p.write_text("foo")
+    monkeypatch.setattr(mount, "EXPECTED_MTP_DEVICE_PATH", mtp_path)
+
+    block_path = tmp_path / "block"
+    block_path.mkdir()
+    p = block_path / "some_block_file.fit"
+    p.write_text("baa")
+    monkeypatch.setattr(mount, "EXPECTED_BLOCK_DEVICE_PATH", block_path)

--- a/tests/db_tests/test_mount_device.py
+++ b/tests/db_tests/test_mount_device.py
@@ -13,6 +13,7 @@ from wkz import models
 
 def test_mount_device_and_collect_files(db, monkeypatch, caplog, tmpdir):
     caplog.set_level(logging.DEBUG, logger="wkz.device.mount")
+    caplog.set_level(logging.DEBUG, logger="wkz.io.fit_collector")
     # mock huey task away to actually test content of function mount_device_and_collect_files
     from workoutizer import settings as django_settings
 

--- a/tests/unit_tests/device/test_mount.py
+++ b/tests/unit_tests/device/test_mount.py
@@ -67,12 +67,12 @@ def test_wait_for_device_and_mount(monkeypatch, _mock_lsusb, caplog, mock_dev, m
     # try to mount device where no device is connected at all
     _mock_lsusb(lsusb_no_garmin_device_at_all)
     with pytest.raises(mount.FailedToMountDevice, match="Expected output of 'lsusb' to contain string 'Garmin'."):
-        mount.wait_for_device_and_mount()
+        mount._wait_for_device_and_mount()
 
     # try to mount device where device is not ready
     _mock_lsusb(lsusb_device_not_ready_to_be_mounted)
     with pytest.raises(mount.FailedToMountDevice):
-        mount.wait_for_device_and_mount()
+        mount._wait_for_device_and_mount()
 
     from tests.conftest import MOCKED_RETRY, MOCKED_WAIT
 
@@ -98,7 +98,7 @@ def test_wait_for_device_and_mount(monkeypatch, _mock_lsusb, caplog, mock_dev, m
 
     # try to mount device which is ready to be mounted from the beginning on
     _mock_lsusb(lsusb_ready_to_be_mounted_device)
-    path = mount.wait_for_device_and_mount()
+    path = mount._wait_for_device_and_mount()
 
     assert "device seems to be ready for mount, mounting..." in caplog.text
     if mock_dev == "MTP":
@@ -145,21 +145,12 @@ def test_wait_for_device_and_mount__first_not_but_then_ready(
     monkeypatch.setattr(mount, "_determine_device_type", _determine_device_type)
 
     # call function to be tested
-    mount_path = mount.wait_for_device_and_mount()
+    mount_path = mount._wait_for_device_and_mount()
 
     assert "device is not ready for mounting yet, waiting 0.1 seconds..." in caplog.text
     assert "device seems to be ready for mount, mounting..." in caplog.text
     assert f"device at path {path} is of type {mock_dev}" in caplog.text
     assert f"successfully mounted device at: {mount_path}" in caplog.text
-
-
-def test__get_mounted_path():
-    mount_output = "Mounted at /media/garmin"
-    assert mount._get_mounted_path(mount_output) == "/media/garmin"
-
-    mount_output = "String not containing keyword"  # missing "Mounted"
-    with pytest.raises(mount.FailedToMountDevice):
-        mount._get_mounted_path(mount_output)
 
 
 def test_garmin_device_connected(_mock_lsusb):

--- a/tests/unit_tests/device/test_mount.py
+++ b/tests/unit_tests/device/test_mount.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -159,3 +160,18 @@ def test_garmin_device_connected(_mock_lsusb):
 
     _mock_lsusb(output=lsusb_no_garmin_device_at_all)
     assert mount.garmin_device_connected() is False
+
+
+def test__device_type_is_mounted(tmp_path):
+    # neither is path a dir nor does it contain anything
+    assert mount._device_type_is_mounted(expected_path=Path("no_path")) is False
+
+    # path is dir but does not contain anything
+    assert mount._device_type_is_mounted(expected_path=Path(tmp_path)) is False
+
+    # path is dir and contains a file
+    d = tmp_path / "subfolder"
+    d.mkdir()
+    p = d / "some_file.txt"
+    p.write_text("foo")
+    assert mount._device_type_is_mounted(expected_path=Path(d)) is True

--- a/wkz/device/mount.py
+++ b/wkz/device/mount.py
@@ -1,7 +1,9 @@
 import logging
 import subprocess
 import time
-from typing import Tuple
+from enum import Enum
+from pathlib import Path
+from typing import Tuple, Union
 
 import pyudev
 
@@ -12,6 +14,8 @@ RETRIES = 5
 WAIT = 20
 DEVICE_READY_STRING = "Garmin International"
 DEVICE_NOT_READY_STRING = "(various models)"
+EXPECTED_MTP_DEVICE_PATH = Path("/run/user/1000/gvfs/")
+EXPECTED_BLOCK_DEVICE_PATH = Path("/media/garmin/")
 
 
 log = logging.getLogger(__name__)
@@ -21,9 +25,19 @@ class FailedToMountDevice(Exception):
     pass
 
 
+class DeviceType(Enum):
+    MTP = "mtp"
+    BLOCK = "block"
+
+
 def mount_device_and_collect_files() -> None:
     try:
-        path_to_garmin_device = wait_for_device_and_mount()
+        path_to_garmin_device = _get_path_of_mounted_device()
+        if path_to_garmin_device:
+            log.debug(f"found mounted garmin device at: {path_to_garmin_device}, will skip mounting")
+        else:
+            log.debug("no device mounted yet, will mount...")
+            path_to_garmin_device = _wait_for_device_and_mount()
 
         # sleep for a second after mounting to avoid IO error
         time.sleep(1)
@@ -38,7 +52,7 @@ def mount_device_and_collect_files() -> None:
         log.error(f"Failed to mount device: {e}")
 
 
-def wait_for_device_and_mount() -> str:
+def _wait_for_device_and_mount() -> str:
     """
     Function to be called whenever a garmin device is connected via USB. Since it takes a moment for the device to be
     accessible and ready to be mounted we need to wait until the `lsusb` command has "Garmin International" in its
@@ -47,33 +61,25 @@ def wait_for_device_and_mount() -> str:
     if not garmin_device_connected():
         raise FailedToMountDevice("Expected output of 'lsusb' to contain string 'Garmin'.")
     log.debug("checking device to be ready for mount...")
-    for _ in range(RETRIES):
+    for n in range(RETRIES):
         lsusb = _get_lsusb_output()
         if DEVICE_READY_STRING in lsusb and DEVICE_NOT_READY_STRING not in lsusb:
             path = _get_path_to_device(lsusb)
             log.debug("device seems to be ready for mount, mounting...")
-            mount_output = _determine_type_and_mount(path)
-            if "Mounted" in mount_output:
-                mounted_path = _get_mounted_path(mount_output)
-                log.info(f"successfully mounted device at: {mounted_path}")
-                return mounted_path
+            device_type = _determine_type_and_mount(path)
+            if device_type == DeviceType.MTP and _device_type_is_mounted(EXPECTED_MTP_DEVICE_PATH):
+                log.info(f"successfully mounted device at: {EXPECTED_MTP_DEVICE_PATH}")
+                return EXPECTED_MTP_DEVICE_PATH
+            elif device_type == DeviceType.BLOCK and _device_type_is_mounted(EXPECTED_BLOCK_DEVICE_PATH):
+                log.info(f"successfully mounted device at: {EXPECTED_BLOCK_DEVICE_PATH}")
+                return EXPECTED_BLOCK_DEVICE_PATH
             else:
-                raise FailedToMountDevice(f"Mount command did not return expected output: {mount_output}")
+                log.warning(f"unable to mount device of type: {device_type}, will retry {RETRIES - n} more time(s)...")
         else:
             log.info(f"device is not ready for mounting yet, waiting {WAIT} seconds...")
             time.sleep(WAIT)
     log.warning(f"could not mount device within time window of {RETRIES * WAIT} seconds.")
     raise FailedToMountDevice(f"Unable to mount device after {RETRIES} retries, with {WAIT}s delay each.")
-
-
-def _get_mounted_path(mount_output: str) -> str:
-    if "Mounted" not in mount_output:
-        raise FailedToMountDevice(
-            f"Output of mount command does not look as expected: {mount_output}. Expected to contain 'Mounted'."
-        )
-    path_start = mount_output.find("at")
-    mount_path = mount_output[path_start + 3 :]
-    return mount_path
 
 
 def _get_path_to_device(lsusb_output: str) -> str:
@@ -90,21 +96,21 @@ def _get_path_to_device(lsusb_output: str) -> str:
             return path
 
 
-def _mount_device_using_gio(path: str) -> str:
-    return subprocess.check_output(["gio", "mount", "-d", path]).decode("utf-8").rstrip()
+def _mount_device_using_gio(path: str) -> None:
+    subprocess.check_output(["gio", "mount", "-d", path]).decode("utf-8").rstrip()
 
 
-def _mount_device_using_pmount(path: str) -> str:
+def _mount_device_using_pmount(path: str) -> None:
     subprocess.check_output(["pmount", path, "garmin"]).decode("utf-8")
-    # pmount does not return anything, assume command to be successful and return expected string
-    return "Mounted at /media/garmin"
 
 
 def garmin_device_connected() -> bool:
     try:
         lsusb = _get_lsusb_output()
     except (FileNotFoundError, subprocess.CalledProcessError):
-        raise FailedToMountDevice("No 'lsusb' command available on your system.")
+        raise FailedToMountDevice(
+            "No 'lsusb' command available on your system. Workoutizer will not be able to mount your Garmin device"
+        )
     if "Garmin" in lsusb:
         return True
     else:
@@ -115,19 +121,20 @@ def _get_lsusb_output() -> str:
     return subprocess.check_output("lsusb").decode("utf8")
 
 
-def _determine_type_and_mount(path: str) -> str:
+def _determine_type_and_mount(path: str) -> DeviceType:
     device_type, path = _determine_device_type(path)
     log.debug(f"device at path {path} is of type {device_type}")
     try:
-        if device_type == "MTP":
-            return _mount_device_using_gio(path)
-        elif device_type == "BLOCK":
-            return _mount_device_using_pmount(path)
+        if device_type == DeviceType.MTP:
+            _mount_device_using_gio(path)
+        elif device_type == DeviceType.BLOCK:
+            _mount_device_using_pmount(path)
+        return device_type
     except subprocess.CalledProcessError as e:
         raise FailedToMountDevice(f"Execution of mount command failed: {e}")
 
 
-def _determine_device_type(path: str) -> Tuple[str, str]:
+def _determine_device_type(path: str) -> Tuple[DeviceType, str]:
     log.debug(f"trying to determine device type for device at: {path}...")
     try:
         device_tree = pyudev.Context()
@@ -136,12 +143,12 @@ def _determine_device_type(path: str) -> Tuple[str, str]:
 
     # check if device is of type MTP
     if _is_of_type_mtp(device_tree):
-        return "MTP", path
+        return DeviceType.MTP, path
 
     # check if device is of type BLOCK
     block_device_path = _get_block_device_path(device_tree, path)
     if block_device_path:
-        return "BLOCK", block_device_path
+        return DeviceType.BLOCK, block_device_path
     else:
         raise FailedToMountDevice("Could not determine device type. Device is neither MTP nor BLOCK.")
 
@@ -162,3 +169,17 @@ def _get_block_device_path(device_tree: pyudev.core.Context, path: str) -> str:
         for device in block_devices:
             if vendor_id == device.get("ID_VENDOR_ID"):
                 return device.get("DEVNAME")
+
+
+def _device_type_is_mounted(expected_path: Path) -> bool:
+    return expected_path.is_dir() and any(expected_path.iterdir())
+
+
+def _get_path_of_mounted_device() -> Union[bool, str]:
+    log.debug("sanity check to see if a device is already mounted...")
+    if _device_type_is_mounted(EXPECTED_MTP_DEVICE_PATH):
+        return str(EXPECTED_MTP_DEVICE_PATH.absolute())
+    elif _device_type_is_mounted(EXPECTED_BLOCK_DEVICE_PATH):
+        return str(EXPECTED_BLOCK_DEVICE_PATH.absolute())
+    else:
+        return False

--- a/wkz/device/mount.py
+++ b/wkz/device/mount.py
@@ -74,7 +74,9 @@ def _wait_for_device_and_mount() -> str:
                 log.info(f"successfully mounted device at: {EXPECTED_BLOCK_DEVICE_PATH}")
                 return EXPECTED_BLOCK_DEVICE_PATH
             else:
-                log.warning(f"unable to mount device of type: {device_type}, will retry {RETRIES - n} more time(s)...")
+                log.warning(
+                    f"unable to mount device of type: {device_type}, will retry {RETRIES - (n+1)} more time(s)..."
+                )
         else:
             log.info(f"device is not ready for mounting yet, waiting {WAIT} seconds...")
             time.sleep(WAIT)


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure pre-commit formatting checks are passing
- [x] changelog entry


Updated the mounting mechanism to account for new `gio` on Raspberry Pi OS bullseye
  which does no longer return the path to a mounted device. The mount mechanism was
  changed in a way that it simply checks whether a device is mounted a the expected
  location. This should work with in all scenarios.