### PR TITLE
CLN: drop usage of `requests`, use `urllib` instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Removed the usage of Dask & distributed for parallel file importing. The speed up
   of using dask was not as high as expected. Reason being the database bottleneck.
   Thus removing the dependency and falling back to purely sequential file imports.
+* Removed `requests` library. Functionality is covered by stdlib `urllib` also.
 ### Added
 * Added support for Python3.10.
 ### Fixed

--- a/poetry.lock
+++ b/poetry.lock
@@ -1498,7 +1498,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "4b749c1f4f3748f3bfa6c3ed261d10cf0d52dd762823f6871d64b771a251fe04"
+content-hash = "ab8e71e406544ebf930a325c99e87aad8aae2b67a9d938f33fb8fdda72ffa2a2"
 
 [metadata.files]
 appnope = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ luddite = "^1.0.2"
 numpy = "^1.22.2"
 pandas = "^1.4.1"
 psutil = "^5.9.0"
-requests = "^2.27.1"
 sportgems = "^0.7.1"        # starting from 0.7.0 supports Python3.10 while support for 3.7 was dropped
 tenacity = "^8.0.1"
 pyudev = "^0.23.2"

--- a/wkz/api.py
+++ b/wkz/api.py
@@ -26,7 +26,7 @@ def mount_device_endpoint(request):
         return Response("No Garmin device connected.", status=status.HTTP_200_OK)
 
 
-@api_view(["POST"])
+@api_view(["POST", "GET"])
 def stop_django_server(request):
     log.info("Stopped.")
     pid = os.getpid()


### PR DESCRIPTION
- [x] tests added / passed
- [x] Ensure pre-commit formatting checks are passing
- [x] changelog entry
